### PR TITLE
Use :message_received event to trigger interpret_monitor instead of /./

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.0.0
 script: bundle exec rake
 before_install:
-  - gem update --system
+  - gem update bundler
 services:
   - redis-server
+sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
 
 gemspec
+
+# TODO: Remove this once a version supporting the :message_received event trigger has been released
+gem 'lita', git: 'https://github.com/PagerDuty/lita.git', branch: 'v4.7.0-improved'

--- a/lita-google-translate.gemspec
+++ b/lita-google-translate.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", ">= 4.4"
+  # TODO: Specify lita version supporting :message_received trigger once there's a release
+  spec.add_runtime_dependency "lita", ">= 4.7"
   spec.add_runtime_dependency "to_lang", "1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,6 +2,7 @@ en:
   lita:
     handlers:
       google_translate:
+        invalid_language: "'%{code}' is not a valid language code. A full list of supported languages can be found at %{url}"
         help:
           translate_key: "translate TEXT"
           translate_value: "Translates TEXT to the default language."
@@ -11,3 +12,4 @@ en:
           interpret_value: "Interprets your messages on the fly until you type !interpret. (FROM and TO are optional language codes)"
           languages_key: "languages"
           languages_value: "Sends a list of language codes supported by lita-google-translate."
+        languages: "A full list of supported languages can be found at %{url}"

--- a/spec/lita/handlers/google_translate_spec.rb
+++ b/spec/lita/handlers/google_translate_spec.rb
@@ -16,7 +16,6 @@ describe Lita::Handlers::GoogleTranslate, lita_handler: true do
   it { is_expected.to route_command("t() hola").to(:translate) }
   it { is_expected.to route_command("interpret(es:en)").to(:interpret_start) }
   it { is_expected.to route_command("interpret(es:en) hola").to(:interpret_start) }
-  it { is_expected.to route("hola").to(:interpret_monitor) }
   it { is_expected.to route("!interpret").to(:interpret_stop) }
   it { is_expected.to route_command("languages").to(:languages) }
 
@@ -33,7 +32,7 @@ describe Lita::Handlers::GoogleTranslate, lita_handler: true do
       it "translates with TO parameter" do
         send_command "translate(EL) hello"
         expect(replies.count).to eq 1
-        expect(replies.first).to match "Γεια σας"
+        expect(replies.first).to match "Χαίρετε"
       end
 
       it "translates with TO and FROM parameters" do
@@ -51,13 +50,13 @@ describe Lita::Handlers::GoogleTranslate, lita_handler: true do
       it "responds with an error message when an invalid source language is given" do
         send_command "translate(asdf:en) hej"
         expect(replies.count).to eq 1
-        expect(replies.first).to match /^'asdf' is not a valid language code\. For available languages, send me the command: languages$/
+        expect(replies.first).to match /^'asdf' is not a valid language code\. A full list of supported languages can be found at https:\/\/github\.com\/tristaneuan\/lita-google-translate#supported-languages$/
       end
 
       it "responds with an error message when an invalid target language is given" do
         send_command "translate(es:hjkl) hola"
         expect(replies.count).to eq 1
-        expect(replies.first).to match /^'hjkl' is not a valid language code\. For available languages, send me the command: languages$/
+        expect(replies.first).to match /^'hjkl' is not a valid language code\. A full list of supported languages can be found at https:\/\/github\.com\/tristaneuan\/lita-google-translate#supported-languages$/
       end
 
     end
@@ -77,7 +76,7 @@ describe Lita::Handlers::GoogleTranslate, lita_handler: true do
       it "responds with an error message when an invalid language is given" do
         send_command "interpret(asdf)"
         expect(replies.count).to eq 1
-        expect(replies.first).to match /^'asdf' is not a valid language code\. For available languages, send me the command: languages$/
+        expect(replies.first).to match /^'asdf' is not a valid language code\. A full list of supported languages can be found at https:\/\/github\.com\/tristaneuan\/lita-google-translate#supported-languages$/
       end
 
       after(:each) do
@@ -129,7 +128,7 @@ describe Lita::Handlers::GoogleTranslate, lita_handler: true do
     it "responds with a list of languages and their codes" do
       send_command "languages"
       expect(replies.count).to eq 1
-      expect(replies.first).to match /^afrikaans: af\nalbanian: sq\n/
+      expect(replies.first).to match /^A full list of supported languages can be found at https:\/\/github\.com\/tristaneuan\/lita-google-translate#supported-languages/
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "simplecov"
 require "coveralls"
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
This change removes the catch-all `/./` chat route in favor of using a
`:message_received` event route to trigger `interpret_monitor`.
